### PR TITLE
Update tinfoil.json

### DIFF
--- a/tinfoil.json
+++ b/tinfoil.json
@@ -31,6 +31,11 @@
             "action": "add"
         },
         {
+            "url": "https://work.wdvip.com.br/shop.tfl",
+            "title": "[Open NX] world digital VIP",
+            "action": "add"
+        },
+        {
             "url": "https://gandalfsax.com",
             "title": "[Open NX] Gandalf eShop",
             "action": "add"


### PR DESCRIPTION
worldigital-brasil accidently leaked their VIP index. Don't know how long it will work for. Their success message does state to disable free when using VIP, users can choose to do that if they wish/know how.

Also, as a tip, these shops should be loaded as the directories json key and not just added to user's File Browser (locations key). Gives you more control if shops die out for users who may not know how to delete entries in their Tinfoil File Browser.