### PR TITLE
Update README with Magic Monkei and Ghost eShop info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ Title: Open NX
 
 ## Current Shops in Open NX:
 
+### Magic Monkei
+
+VIP Tinfoil Shop. [Subscribe](https://app.magicmonkei.com/signup?r=opennx) to Magic Monkei and access a vast library of Tinfoil games. 
+Next, add your user tinfoil server:
+
+```
+Protocol: https
+Host: magicmonkei.com
+Path: /tinfoil
+Username: your-username 
+Password: your-password
+Title: Magic Monkei
+```
+
+Or go to this host and install the Magic Monkei app:
+
+```
+Protocol: https
+Host: magicmonkei.com/app
+Title: Magic Monkei App
+```
+
 ### Ghost eShop
 ```
 Protocol: https
@@ -78,15 +100,6 @@ Host: cyrilz87.net
 Title: Egg Fried Rice Shop
 ```
 
-### Backup of Shops with various Functions
-```
-# JITS (works with your own GDrive if you follow https://games.jits.cc/account#instructions)
-Protocol: https
-Host: games.jits.site
-Path: shop
-Title: JITS
-```
-
 ### Ecchi's Firmware Archives (download all of switch firmware from Tinfoil)
 ```
 Protocol: https
@@ -102,27 +115,7 @@ Host: e.cchi.me
 Title: ESA
 ```
 
-## Magic Monkei
 
-VIP Tinfoil Shop. [Subscribe](https://app.magicmonkei.com/signup?r=opennx) to Magic Monkei and access a vast library of Tinfoil games. 
-Next, add your user tinfoil server:
-
-```
-Protocol: https
-Host: magicmonkei.com
-Path: /tinfoil
-Username: your-username 
-Password: your-password
-Title: Magic Monkei
-```
-
-Or go to this host and install the Magic Monkei app:
-
-```
-Protocol: https
-Host: magicmonkei.com/app
-Title: Magic Monkei App
-```
 ---------
 
 ## Tinfoil Alternatives


### PR DESCRIPTION
Added details for Magic Monkei and Ghost eShop, removed backup shop section.