### PR TITLE
Rename Emre Game Shop to Pixel Goblin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ Host: gandalfsax.com
 Title: Gandalf eShop
 ```
 
-### [Emre Game Shop](https://tinfoil.emre.zip)
+### [Pixel Goblin](https://pixelgoblin.link/)
 
-Paid Tinfoil shop. 3-day free trial available. [Sign up](https://tinfoil.emre.zip/sign-up) to get your credentials.
+Subscription Tinfoil shop with the largest curated Switch library, daily updates, and a 3-day free trial. [Sign up](https://pixelgoblin.link/sign-up) to get your credentials, then add your user tinfoil server:
 
 ```
 Protocol: https
-Host: tinfoil.emre.zip
+Host: pixelgoblin.link
 Path: /api/shop
 Username: your-username
 Password: your-password
-Title: Emre Game Shop
+Title: Pixel Goblin
 ```
 ---------
 

--- a/tinfoil.json
+++ b/tinfoil.json
@@ -9,7 +9,7 @@
         "https://magicmonkei.com",
         "https://myrincon.es/net/Zenten",
         "https://gandalfsax.com/",
-        "https://tinfoil.emre.zip"
+        "https://pixelgoblin.link"
     ],
-    "success": "Open NX Shops status list:\n\nnx-meta.nlib.cc:  Online\nnx-retro.ghostland.at:  Check failed\nnx-saves.ghostland.at:  Check failed\nnx.ghostland.at:  Check failed\ncyrilz87.net:  Invalid content\nfree.worldigital-brasil.com:  Offline (403)\nmagicmonkei.com:  Online\nmyrincon.es:  Online\ngandalfsax.com:  Offline (403)\ntinfoil.emre.zip:  Online\n\nSuggest a new shop on:\nhttps://opennx.github.io/"
+    "success": "Open NX Shops status list:\n\nnx-meta.nlib.cc:  Online\nnx-retro.ghostland.at:  Check failed\nnx-saves.ghostland.at:  Check failed\nnx.ghostland.at:  Check failed\ncyrilz87.net:  Invalid content\nfree.worldigital-brasil.com:  Offline (403)\nmagicmonkei.com:  Online\nmyrincon.es:  Online\ngandalfsax.com:  Offline (403)\npixelgoblin.link:  Online\n\nSuggest a new shop on:\nhttps://opennx.github.io/"
 }

--- a/tinfoil.json
+++ b/tinfoil.json
@@ -11,5 +11,5 @@
         "https://gandalfsax.com/",
         "https://pixelgoblin.link"
     ],
-    "success": "Open NX Shops status list:\n\nnx-meta.nlib.cc:  Online\nnx-retro.ghostland.at:  Check failed\nnx-saves.ghostland.at:  Check failed\nnx.ghostland.at:  Check failed\ncyrilz87.net:  Invalid content\nfree.worldigital-brasil.com:  Offline (403)\nmagicmonkei.com:  Online\nmyrincon.es:  Online\ngandalfsax.com:  Offline (403)\npixelgoblin.link:  Online\n\nSuggest a new shop on:\nhttps://opennx.github.io/"
+    "success": "Open NX Shops status list:\n\nnx-meta.nlib.cc:  Online\nnx-retro.ghostland.at:  Check failed\nnx-saves.ghostland.at:  Check failed\nnx.ghostland.at:  Check failed\ncyrilz87.net:  Invalid content\nfree.worldigital-brasil.com:  Offline (403)\nmagicmonkei.com:  Online\nmyrincon.es:  Online\ngandalfsax.com:  Offline (403)\ntinfoil.emre.zip:  Online\n\nSuggest a new shop on:\nhttps://opennx.github.io/"
 }


### PR DESCRIPTION
## Summary
- Domain migrated from `tinfoil.emre.zip` to `pixelgoblin.link` (canonical)
- Updates `tinfoil.json` directories list
- Updates README "Current Shops" section with new branding and shop info

The old host (`tinfoil.emre.zip`) is now a 301 redirect to `pixelgoblin.link`, so this PR consolidates the listing onto the canonical domain. Existing installer clients on the old host continue to work since `/api/*` paths are exempt from the redirect.

## Test plan
- [x] `tinfoil.json` parses as valid JSON
- [x] `pixelgoblin.link` reachable (HTTP 200) — passes `check_url.py` working-indicator heuristic
- [x] Shop endpoint `https://pixelgoblin.link/api/shop` responds 401 without auth, 200 with valid Basic Auth (Tinfoil/Awoo/DBI compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)