### PR TITLE
Add guide for transitioning from Tinfoil to Cyberfoil

### DIFF
--- a/_posts/2026-05-23-ditching-tinfoil-for-cyberfoil-a-complete-setup-guide.md
+++ b/_posts/2026-05-23-ditching-tinfoil-for-cyberfoil-a-complete-setup-guide.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: "Ditching Tinfoil for Cyberfoil: A Complete Setup Guide"
+date: 2026-05-23 15:25:00 +0100
+categories: guides tutorial
+---
+
+If you’ve been managing a homebrew setup on your Nintendo Switch, chances are you’ve used **Tinfoil**. For years, it was the go-to manager for backup libraries, index shops, and titles. However, many users have grown tired of its heavy footprint, occasional instability, complex UI, or regional language configuration bugs. 
+
+**But the biggest problem? Tinfoil has not been actively updated for a long time.** As Nintendo rolls out newer system firmwares and the Atmosphère custom firmware evolves, relying on an abandoned, closed-source installer means constantly wrestling with crashes, broken features, and looking for unofficial community patches just to keep it running.
+
+Enter **Cyberfoil** — a fast, modern, and lightweight open-source alternative built specifically to address these pain points. Because it is actively developed, it strips away the legacy bloat while offering native compatibility with modern Switch firmware and the network protocols you already use.
+
+In this guide, we will walk you through transitioning from the outdated Tinfoil environment to Cyberfoil, and how to configure it seamlessly using the OpenNX `cyberfoil.json` setup.
+
+---
+
+### Why Choose Cyberfoil Over Tinfoil?
+
+* **Active Development:** Fully compatible with latest firmwares without needing unstable community patches.
+* **Performance:** Cyberfoil boots rapidly and runs with a much lighter footprint on your custom firmware.
+* **Modern UI:** No crowded menus or confusing layouts; it features an intuitive design built for quick navigation.
+* **Open Source:** Transparent development with regular, community-driven fixes.
+* **Standardized Language Handling:** Avoids the common language code system errors that often plague Tinfoil configurations (such as improperly parsed regional codes like `en-US` or `en-GB`).
+
+---
+
+### Prerequisites
+Before making the switch, ensure you have:
+1. **A Modded Nintendo Switch** running custom firmware (Atmosphère).
+2. An active **internet connection** configured on your Switch (with robust DNS blocking, like Exosphere or DNS MITM, to keep your console safe).
+
+---
+
+## Moving to Cyberfoil: The Step-by-Step Transition
+
+Switching over is straightforward because Cyberfoil handles your existing repository connections natively. You don't even need to completely delete Tinfoil right away if you prefer to test them side-by-side.
+
+### Step 1: Download and Install Cyberfoil
+Instead of dealing with full pack reinstallations just to update your tools, you can install and update Cyberfoil independently to preserve your main settings.
+
+1. Head over to the [Official Cyberfoil GitHub Releases Page](https://github.com/luketanti/CyberFoil/releases).
+2. Download the latest `cyberfoil.nro` file.
+3. Insert your Switch’s SD card into your computer (or use an FTP/DBI MTP responder tool).
+4. Drop the `cyberfoil.nro` file directly into your `sdmc:/switch/` folder.
+
+---
+
+### Step 2: Launching Cyberfoil (via HBMenu or Sphaira)
+To open Cyberfoil, you can use the classic Homebrew Menu, or you can take advantage of the increasingly popular, modern **Sphaira** environment. 
+
+If you are using **Sphaira** as your main homebrew launcher interface, it will automatically detect the application file. Simply navigate to your main homebrew dashboard list within Sphaira, locate the Cyberfoil icon, and select it to launch. 
+
+Once opened, you will be greeted by Cyberfoil's clean, modern tile layout:
+
+<img width="1280" height="720" alt="2026052315154600-1E91DE9ADA44E48665B17E11B1E899DB" src="https://github.com/user-attachments/assets/7d506413-4391-41ca-bce0-120f08ffcbdd" />
+
+---
+
+### Step 3: Configuring the OpenNX Shop Repository
+Tinfoil relies on adding traditional, sometimes bloated index URLs. Cyberfoil simplifies this by reading clean JSON index configurations. We will look at the public OpenNX forwarder config hosted transparently at `opennx.github.io/cyberfoil.json`.
+
+1. **Open the Settings Menu:** Using the D-Pad or touch controls, select the **Settings** tile gear icon at the bottom center of the main screen. Once inside, press **L** or **R** to jump over to the **Shop** section tab on the left menu sidebar.
+2. **Select Add New Shop:** Scroll down the Shop list options and select **Add new shop**.
+   
+   <img width="1280" height="720" alt="2026052315170000-1E91DE9ADA44E48665B17E11B1E899DB" src="https://github.com/user-attachments/assets/4a1900a4-9462-4378-88c7-38c6e794e89e" />
+
+3. **Set the Shop Protocol:** A prompt will appear asking you to choose the network protocol. Select **HTTPS** to ensure a secure connection to the repository host.
+   
+  <img width="1280" height="720" alt="2026052315161300-1E91DE9ADA44E48665B17E11B1E899DB" src="https://github.com/user-attachments/assets/fc3bf98d-df05-4c8a-8e58-c1509f615943" />
+
+4. **Select the Shop Port:** Next, the app will ask you to pick which port to use. Select **Use default (443)** which is the standard automated port assignment for secure web connections.
+   
+   <img width="1280" height="720" alt="2026052315163400-1E91DE9ADA44E48665B17E11B1E899DB" src="https://github.com/user-attachments/assets/72efb55b-eee8-443b-a0dd-48328181be6d" />
+
+5. **Input the OpenNX Server Paths:** You will now be prompted to fill in the exact server addresses. Enter the following details carefully:
+   * **Host:** `opennx.github.io`
+   * **Path:** `/cyberfoil.json`
+   * **Title:** `Open NX`
+   
+   *(Leave Username and Password completely **blank**, as this public repository forwarder doesn't require private authentication).*
+6. **Enable Tinfoil Mode Compatibility:** Before exiting, make sure the **Tinfoil Mode (legacy shop compatibility)** checkbox is ticked. This ensures that the custom index parsing structures mapped by OpenNX translate perfectly onto Cyberfoil's modern UI environment.
+   
+   <img width="1280" height="720" alt="2026052315165700-1E91DE9ADA44E48665B17E11B1E899DB" src="https://github.com/user-attachments/assets/ae4b7bb3-225d-4aac-ae18-161bcb0e06b2" />
+
+---
+
+### Step 4: Refresh and Browse Your Library
+Once the network path is locked in:
+
+1. Press **B** to back out and save your settings, then **Restart Cyberfoil** (or trigger a manual refresh from the application UI).
+2. The app will fetch the layout directly from `https://opennx.github.io/cyberfoil.json`.
+3. Select the **Install from eShop** tile on your main menu. Your game lists, active updates, and library titles will instantly populate on the screen, ready for a smoother, faster experience than traditional Tinfoil layouts.
+
+> **Troubleshooting Connection Issues:** If you encounter a connection error, double-check your spelling on the host and path fields. If your network blocks GitHub Pages, you can use the raw fallback path: **Protocol:** `https` | **Host:** `raw.githubusercontent.com` | **Path:** `OpenNX/opennx.github.io/main/cyberfoil.json`.
+
+***
+
+*Disclaimer: This tutorial is intended purely for educational and homebrew management purposes. Always ensure you are adhering to local regulations and utilizing your own legally obtained backups.*


### PR DESCRIPTION
This post provides a comprehensive guide on transitioning from Tinfoil to Cyberfoil for Nintendo Switch users, detailing installation steps, configuration, and advantages of using Cyberfoil.