### PR TITLE
Add troubleshooting guide for Tinfoil game title issues

### DIFF
--- a/_posts/2026-06-10-fix-tinfoil-not-showing-game-titles-only-codes.md
+++ b/_posts/2026-06-10-fix-tinfoil-not-showing-game-titles-only-codes.md
@@ -1,0 +1,77 @@
+---
+layout: post
+title: "How to Fix Tinfoil Not Showing Game Titles (Only Showing Codes)"
+date: 2026-06-10 13:40:00 +0100
+categories: troubleshooting guides
+---
+
+If you are managing a custom setup on your modded Nintendo Switch, you have likely run into one of Tinfoil's most frustrating legacy bugs: opening your shop or library tab only to find that **game titles have completely disappeared, leaving behind nothing but raw application ID codes (like `01007ef00011e000`)**.
+
+Without proper game names, icons, or descriptions, browsing your backup index effectively becomes a guessing game. 
+
+Because Tinfoil caches web files locally to parse its custom menus, this bug frequently triggers during unexpected database timeouts or minor firmware shifts. Luckily, there are a few robust ways to force Tinfoil to rebuild its titles catalog—ranging from quick cache clear-outs to injecting stable community infrastructure directly into your index settings.
+
+---
+
+### Why Does This Happen?
+
+This glitch usually breaks down to three main structural culprits:
+1. **Corrupted Local Title Database (`titles.US.en.db`):** Tinfoil caches a local database file on your SD card to map raw hexadecimal game IDs to readable titles. If this file corrupts during a network sync or an abrupt app exit, the text mapping completely breaks.
+2. **Regional Language Discrepancies:** Tinfoil's internal language configuration system is notoriously finicky. If your Switch system language doesn't perfectly align with the shop's database region (e.g., mismatching `en-US` and `en-GB`), the script fails to parse localized strings.
+3. **Missing or Broken Meta Index:** If a public repository changes its directory pathing or experiences structural metadata changes, Tinfoil stops downloading the required icons and text strings natively.
+
+---
+
+## Technical Solutions to Restore Game Titles
+
+If your titles have turned into raw application codes, follow these solutions sequentially to fix the asset mapping.
+
+### Solution 1: Inject the NX Custom Metadata Database
+If your primary shop is missing proper mapping assets entirely due to unstable backend endpoints, you can inject a dedicated community metadata source into your network browser to map the game names correctly.
+
+**Option A: The Automated Open NX Fix (Recommended)**
+If you use the Open NX forwarder, the required custom metadata database is already integrated directly into its configuration. By adding this one file, Tinfoil will automatically route the fix.
+1. Launch Tinfoil and navigate to the **File Browser** tab.
+2. Press **X** to add a new network location.
+3. Enter the following network details:
+   * **Protocol:** `https`
+   * **Host:** `opennx.github.io`
+   * **Path:** `tinfoil.json`
+   * **Title:** `Open NX`
+4. Save and restart. This JSON file automatically maps the metadata database alongside its other layout features.
+
+**Option B: The Manual Custom DB Fix**
+If you prefer to add the metadata server manually without using the Open NX configuration, you can link the raw database directly.
+1. Navigate to the **File Browser** tab and press **X** to add a new network slot.
+2. Fill in the network configuration values exactly as follows:
+   * **Protocol:** `https`
+   * **Host:** `nx-meta.nlib.cc`
+   * **Path:** `/`
+   * **Title:** `NX Custom DB`
+3. Save the entry, then completely **Restart Tinfoil**. Give the application about 2–5 minutes on boot to fully pull down, sync, and map the replacement titles and artwork onto your screen.
+
+### Solution 2: Wipe the Local Cache Database Folder
+Forcing the application to discard its local files and download a fresh title database from your active shop repositories usually resolves corruption issues.
+
+1. Turn off your Switch completely, remove the SD card, and insert it into your computer (or launch an MTP responder server via a tool like DBI).
+2. Navigate to the following path: `sdmc:/switch/tinfoil/`
+3. Look for the directory named **`db`** or individual files ending in a `.db` format—specifically files like **`titles.US.en.db`** (the exact file name varies depending on your region).
+4. **Delete** the `db` folder or the local cache files inside it. 
+5. Insert the SD card back into your console, launch Tinfoil while connected to a verified internet connection, and allow it to sit idly on boot to generate clean directory tables.
+
+### Solution 3: Toggle Global Region Compatibility
+If your system region is causing a string-parsing error on newer system updates, you can toggle Tinfoil's internal options to force a generic, English-fallback language path.
+
+1. Open Tinfoil and navigate to the **Options** tab on the left sidebar.
+2. Locate the **Language** setting entry.
+3. Switch it from *Default* or your specific local sub-region directly to **English** (or switch it to **GB** and then flip it back to **US**).
+4. Restart the application to force the UI to refresh its text layout parsing tables.
+
+---
+
+## Verifying the Fix
+Once you have applied these fixes, head into your **New Games** or **Recommended** tabs. The raw alphanumeric title IDs should be gone, replaced entirely by their proper titles, localized metadata, and visual banners. If titles still fail to populate, ensure your system clock is perfectly synced to internet time, as mismatched secure protocol timestamps can cause metadata downloads to fail silently.
+
+***
+
+*Disclaimer: This troubleshooting tutorial is intended purely for educational and homebrew asset management purposes. Always ensure you utilize your own legally obtained backups.*


### PR DESCRIPTION
This post provides troubleshooting steps for fixing Tinfoil not displaying game titles, including solutions for corrupted databases, regional discrepancies, and cache issues.