### PR TITLE
Create guide for fixing Tinfoil error on Firmware 22.5.0

### DIFF
--- a/_posts/2026-06-30-how-to-fix-tinfoil-error-on-firmware-22-5.md
+++ b/_posts/2026-06-30-how-to-fix-tinfoil-error-on-firmware-22-5.md
@@ -1,0 +1,58 @@
+---
+layout: post
+title: "How to Fix Tinfoil Error on Firmware 22.5.0"
+date: 2026-06-30
+categories: guides troubleshooting firmware
+---
+
+The release of Nintendo Switch Firmware 22.5.0 introduced structural adjustments to the system's software layout, resulting in Tinfoil throwing familiar crashes or the "The software was closed because an error occurred" message upon execution.
+
+Because your operating system actively protects these specific runtime binaries while your console is turned on, standard FTP or homebrew MTP transfer methods will fail silently. For any manual file swaps outlined below, **you must use Hekate's hardware layer** to successfully replace the files. 
+
+Here are the three community-verified methods to fix Tinfoil on modern firmware, ordered by recommendation.
+
+---
+
+### Solution 1: Direct Standalone File Fix (Highly Recommended)
+
+This is the best way to resolve the error if you want to keep your current Custom Firmware setup completely intact without modifying your overall platform settings or custom structures.
+
+1.  **Download the Fix Archive:** Grab the targeted archive containing the working pre-compiled compatibility binaries: **[Download Patched Tinfoil 21+/22.5+ Fix (.rar)](https://www.mediafire.com/file/llifnihm03xhq0u/Tinfoil_21%252B.rar/file)**
+2.  **Enter Hekate:** Power down your console completely, insert your RCM Jig, and boot directly into the **Hekate Bootloader** menu.
+3.  **Mount via Hardware Layer:** Navigate to **Tools > USB Tools** and select **SD Card** to open an unrestricted data link to your computer.
+4.  **Extract and Overwrite:** Extract the downloaded `Tinfoil_21+.rar` file on your PC. Drag and drop the contents directly onto the root level of your microSD card, choosing **\"Yes\"** to overwrite the existing files inside your `/atmosphere/` and `/switch/` paths.
+5.  **Boot and Launch:** Unmount safely, close the menu in Hekate, and boot your CFW environment. Open Tinfoil from your **Homebrew Menu** via title override (holding 'R' while launching an official game).
+
+---
+
+### Solution 2: Integrated Update via CNX Pack (Alternative AIO)
+
+If you use a fully automated suite like the **CNX Pack** (formerly Sphaira) and prefer keeping your entire environmental chain synchronized, the newest updates bundle the necessary compatibility files natively.
+
+1.  **Download the Pack:** Retrieve the latest software tree version built for the current firmware generation:
+    * **[Download CNX Pack v22.5.0-1](https://github.com/CostelaCNX/CNX/releases/tag/22.5.0-1)**
+2.  **Deploy Stack:** Extract and drop the complete configuration directory directly onto the root directory of your microSD card.
+3.  **Verify and Update:** Let the system replace old assets to update your custom modules, signature components, and your native application layers simultaneously.
+
+---
+
+### Solution 3: Pre-Patched Atmosphere Repository (Advanced Clean Install)
+
+If you prefer installing a pristine, pre-patched Atmosphere tree directly from source, developer `jecoteco` maintains a dedicated repository specifically compiled to allow Tinfoil to play nicely with modern firmware layers.
+
+1.  **Retrieve the Source Build:** Head to the official source project and download the latest release branch bundle:
+    * **[Download via jecoteco/Atmosphere-Tinfoil-Patched](https://github.com/jecoteco/Atmosphere-Tinfoil-Patched)**
+2.  **Mount via Hekate:** As with Solution 1, boot into Hekate, go to **Tools > USB Tools**, and mount your SD card over USB.
+3.  **Deploy Pre-Patched Core:** Extract the repository archive on your computer and copy the updated folder structure over the root of your microSD card to overwrite the underlying core files inside your existing `/atmosphere/` path.
+4.  **Boot CFW:** Unmount the storage safely and boot back into your custom environment.
+
+---
+
+### Vital Prerequisites for Core Stability
+
+* **Signature Patches / Sys-patch:** Even with a modified kernel build, Tinfoil will immediately crash without matching signature patches active on your system. Make sure your overall baseline validation is fully up to date.
+* **Avoid Applet Mode:** Launching through the base system Album folder drastically chokes down accessible runtime memory. Always launch through **Title Override** loops to ensure your console allocates full system RAM to the application.
+* **Clock Sync Restrictions:** If you notice the application hanging on the loading screens or freezing while parsing repositories, double-check that your console's clock is synchronized with internet servers in your Switch System Settings.
+
+---
+*Disclaimer: System modifications carry minor risks. Always isolate testing environments to a healthy EmuNAND branch and preserve solid physical backups of raw internal console memory files.*


### PR DESCRIPTION
Added a comprehensive guide on fixing Tinfoil errors on Nintendo Switch Firmware 22.5.0.